### PR TITLE
added FE release template with multiproject management

### DIFF
--- a/io-functions-pay-portal/.devops/azure-templates/node-github-release.yaml
+++ b/io-functions-pay-portal/.devops/azure-templates/node-github-release.yaml
@@ -1,0 +1,114 @@
+# Node Github Relase steps
+# Mark a release on the project repository, with version bump and tag,
+# and publish a release on Github
+
+parameters:
+  # Versioning parameters
+  - name: 'semver'
+    type: string
+    values:
+    - major
+    - minor
+    - patch
+
+  # This is the branch in which we will push the release tag.
+  # It'll be master, but it can be overridden
+  # Basically, this variable is used to enforce the fact that we use the very same branch in different steps
+  - name: 'release_branch'
+    type: string
+    default: master
+
+  # This is the project folder where yarn.lock is present
+  # (in case of multiple project under the same repo)
+  - name: 'project_folder'
+    type: string
+    default: '.'
+
+  # Github parameters
+  - name: 'gitUsername'
+    type: string
+  - name: 'gitEmail'
+    type: string
+  - name: 'gitHubConnection'
+    type: string
+
+  # Node runtime parameters
+  - name: 'nodeVersion'
+    type: string
+  - name: 'pkg_cache_version_id'
+    type: string
+  - name: 'pkg_cache_folder'
+    type: string
+
+
+steps:
+  - checkout: self
+    displayName: 'Checkout'
+    clean: true
+    persistCredentials: true
+
+  # setup git author
+  - script: |
+      git config --global user.email "${{ parameters.gitEmail }}" && git config --global user.name "${{ parameters.gitUsername }}"
+    displayName: 'Git setup' 
+
+  # Without this step, changes would be applied to a detached head
+  - script: |
+      git checkout ${{ parameters.release_branch }}
+    displayName: 'Checkout release branch'
+
+  # # Go to project folder (in case of multiple project under the same repo)
+  # - script: |
+  #     cd ${{ parameters.project_folder }}
+  #   displayName: "Go to project folder"
+        
+  # setup Node runtime
+  - task: UseNode@1
+    inputs:
+      version: '${{ parameters.nodeVersion }}'
+    displayName: 'Set up Node.js'
+  - task: Cache@2
+    inputs:
+      key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | ${{ parameters.project_folder }}/yarn.lock'
+      restoreKeys: |
+        yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"
+      path: '${{ parameters.pkg_cache_folder }}'
+    displayName: 'Cache yarn packages'
+  - script: |
+      yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
+    displayName: 'Install node modules'
+    condition: ne(variables.CACHE_RESTORED, 'true')
+    
+  # bump version
+  # - script: |
+  #     npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
+  #     NEXT_VERSION=$(node -p "require('./${{ parameters.project_folder }}/package.json').version")
+  #     RELEASE_TAG="v$NEXT_VERSION-RELEASE"
+  #     git tag $RELEASE_TAG
+  #   displayName: 'Version bump and tag'
+  # - script: |
+  #     NEXT_VERSION=$(node -p "require('./${{ parameters.project_folder }}/package.json').version")
+  #     HEAD_SHA=$(git rev-parse HEAD)
+  #     TITLE="Release $NEXT_VERSION"
+  #     TAG="v$NEXT_VERSION-RELEASE"
+  #     echo "##vso[task.setvariable variable=title]$TITLE"
+  #     echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
+  #     echo "##vso[task.setvariable variable=tag]$TAG"
+  #   displayName: 'Set release variables'
+
+  # push new version
+  # - script: |
+  #     git push origin ${{ parameters.release_branch }} && git push --tags
+  #   displayName: 'Push to the release branch'
+
+  # create new releae
+  # - task: GitHubRelease@0
+  #   inputs:
+  #     gitHubConnection: ${{ parameters.gitHubConnection }}
+  #     repositoryName: $(Build.Repository.Name)
+  #     action: create
+  #     target: $(sha)
+  #     tagSource: manual
+  #     tag: $(tag)
+  #     title: $(title)
+  #     addChangelog: true

--- a/io-functions-pay-portal/.devops/deploy-function-app.yml
+++ b/io-functions-pay-portal/.devops/deploy-function-app.yml
@@ -41,33 +41,34 @@ stages:
   # - is on branch master 
   # - is a tag in the form v{version}-RELEASE
   - stage: Release
-    condition:
-      and(
-        succeeded(),
-        or(
-          eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-          and(
-            startsWith(variables['Build.SourceBranch'], 'refs/tags'),
-            endsWith(variables['Build.SourceBranch'], '-RELEASE')
-          )
-        )
-      )
+    # condition:
+    #   and(
+    #     succeeded(),
+    #     or(
+    #       eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+    #       and(
+    #         startsWith(variables['Build.SourceBranch'], 'refs/tags'),
+    #         endsWith(variables['Build.SourceBranch'], '-RELEASE')
+    #       )
+    #     )
+    #   )
     pool:
       vmImage: 'ubuntu-latest'
     jobs:
       - job: make_release
         steps:
-        - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-          - template: templates/node-github-release/template.yaml@pagopaCommons 
-            parameters:
-              release_branch: 'main'
-              semver: '${{ parameters.RELEASE_SEMVER }}'
-              gitEmail: $(GIT_EMAIL)
-              gitUsername: $(GIT_USERNAME)
-              gitHubConnection: $(GITHUB_CONNECTION)
-              nodeVersion: $(NODE_VERSION)
-              pkg_cache_version_id: $(CACHE_VERSION_ID)
-              pkg_cache_folder: $(YARN_CACHE_FOLDER)
+        # - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        - template: azure-templates/node-github-release.yaml 
+          parameters:
+            release_branch: 'main'
+            project_folder: 'io-functions-pay-portal/'
+            semver: '${{ parameters.RELEASE_SEMVER }}'
+            gitEmail: $(GIT_EMAIL)
+            gitUsername: $(GIT_USERNAME)
+            gitHubConnection: $(GITHUB_CONNECTION)
+            nodeVersion: $(NODE_VERSION)
+            pkg_cache_version_id: $(CACHE_VERSION_ID)
+            pkg_cache_folder: $(YARN_CACHE_FOLDER)
 
         - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
           - script: |

--- a/io-pay-portal-fe/.devops/azure-templates/make-build.yml
+++ b/io-pay-portal-fe/.devops/azure-templates/make-build.yml
@@ -2,11 +2,13 @@
   
 steps:
 - bash: |
-    echo 'IO_PAY_PORTAL_FUNCTION: $IO_PAY_PORTAL_FUNCTION'
+    echo 'IO_PAY_PORTAL_API_HOST: $IO_PAY_PORTAL_API_HOST'
+    echo 'IO_PAY_PORTAL_API_REQUEST_TIMEOUT: $IO_PAY_PORTAL_API_REQUEST_TIMEOUT'
     chmod +x env.sh && source env.sh
     yarn build
   workingDirectory: io-pay-portal-fe
   env:
-    IO_DEVELOPER_PORTAL_PORT: $(IO_PAY_PORTAL_FUNCTION)
+    IO_PAY_PORTAL_API_HOST: $(IO_PAY_PORTAL_API_HOST)
+    IO_PAY_PORTAL_API_REQUEST_TIMEOUT: $(IO_PAY_PORTAL_API_REQUEST_TIMEOUT)
   displayName: 'Build files'
   

--- a/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
+++ b/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
@@ -1,0 +1,113 @@
+# Node Github Relase steps
+# Mark a release on the project repository, with version bump and tag,
+# and publish a release on Github
+
+parameters:
+  # Versioning parameters
+  - name: "semver"
+    type: string
+    values:
+      - major
+      - minor
+      - patch
+
+  # This is the branch in which we will push the release tag.
+  # It'll be master, but it can be overridden
+  # Basically, this variable is used to enforce the fact that we use the very same branch in different steps
+  - name: "release_branch"
+    type: string
+    default: master
+
+  # This is the project folder where yarn.lock is present
+  # (in case of multiple project under the same repo)
+  - name: "project_folder"
+    type: string
+    default: "."
+
+  # Github parameters
+  - name: "gitUsername"
+    type: string
+  - name: "gitEmail"
+    type: string
+  - name: "gitHubConnection"
+    type: string
+
+  # Node runtime parameters
+  - name: "nodeVersion"
+    type: string
+  - name: "pkg_cache_version_id"
+    type: string
+  - name: "pkg_cache_folder"
+    type: string
+
+steps:
+  - checkout: self
+    displayName: "Checkout"
+    clean: true
+    persistCredentials: true
+
+  # setup git author
+  - script: |
+      git config --global user.email "${{ parameters.gitEmail }}" && git config --global user.name "${{ parameters.gitUsername }}"
+    displayName: "Git setup"
+
+  # Without this step, changes would be applied to a detached head
+  - script: |
+      git checkout ${{ parameters.release_branch }}
+    displayName: "Checkout release branch"
+
+    # Go to project folder (in case of multiple project under the same repo)
+  - script: |
+      cd ${{ parameters.project_folder }}
+    displayName: "Go to project folder"
+
+  # setup Node runtime
+  - task: UseNode@1
+    inputs:
+      version: "${{ parameters.nodeVersion }}"
+    displayName: "Set up Node.js"
+  - task: Cache@2
+    inputs:
+      key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | yarn.lock'
+      restoreKeys: |
+        yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"
+      path: "${{ parameters.pkg_cache_folder }}"
+    displayName: "Cache yarn packages"
+  - script: |
+      yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
+    displayName: "Install node modules"
+    condition: ne(variables.CACHE_RESTORED, 'true')
+
+  # bump version
+  - script: |
+      npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
+      NEXT_VERSION=$(node -p "require('./package.json').version")
+      RELEASE_TAG="v$NEXT_VERSION-RELEASE"
+      git tag $RELEASE_TAG
+    displayName: "Version bump and tag"
+  - script: |
+      NEXT_VERSION=$(node -p "require('./package.json').version")
+      HEAD_SHA=$(git rev-parse HEAD)
+      TITLE="Release $NEXT_VERSION"
+      TAG="v$NEXT_VERSION-RELEASE"
+      echo "##vso[task.setvariable variable=title]$TITLE"
+      echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
+      echo "##vso[task.setvariable variable=tag]$TAG"
+    displayName: "Set release variables"
+
+  # push new version
+  - script: |
+      git push origin ${{ parameters.release_branch }} && git push --tags
+    displayName: "Push to the release branch"
+
+  # create new releae
+  - task: GitHubRelease@0
+    inputs:
+      gitHubConnection: ${{ parameters.gitHubConnection }}
+      repositoryName: $(Build.Repository.Name)
+      action: create
+      target: $(sha)
+      tagSource: manual
+      tag: $(tag)
+      title: $(title)
+      addChangelog: true

--- a/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
+++ b/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
@@ -69,6 +69,7 @@ steps:
     displayName: 'Set up Node.js'
   - task: Cache@2
     inputs:
+      workingDirectory: io-pay-portal-fe
       key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | yarn.lock'
       restoreKeys: |
         yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"

--- a/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
+++ b/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
@@ -4,87 +4,88 @@
 
 parameters:
   # Versioning parameters
-  - name: "semver"
+  - name: 'semver'
     type: string
     values:
-      - major
-      - minor
-      - patch
+    - major
+    - minor
+    - patch
 
   # This is the branch in which we will push the release tag.
   # It'll be master, but it can be overridden
   # Basically, this variable is used to enforce the fact that we use the very same branch in different steps
-  - name: "release_branch"
+  - name: 'release_branch'
     type: string
     default: master
 
   # This is the project folder where yarn.lock is present
   # (in case of multiple project under the same repo)
-  - name: "project_folder"
+  - name: 'project_folder'
     type: string
-    default: "."
+    default: '.'
 
   # Github parameters
-  - name: "gitUsername"
+  - name: 'gitUsername'
     type: string
-  - name: "gitEmail"
+  - name: 'gitEmail'
     type: string
-  - name: "gitHubConnection"
+  - name: 'gitHubConnection'
     type: string
 
   # Node runtime parameters
-  - name: "nodeVersion"
+  - name: 'nodeVersion'
     type: string
-  - name: "pkg_cache_version_id"
+  - name: 'pkg_cache_version_id'
     type: string
-  - name: "pkg_cache_folder"
+  - name: 'pkg_cache_folder'
     type: string
+
 
 steps:
   - checkout: self
-    displayName: "Checkout"
+    displayName: 'Checkout'
     clean: true
     persistCredentials: true
 
   # setup git author
   - script: |
       git config --global user.email "${{ parameters.gitEmail }}" && git config --global user.name "${{ parameters.gitUsername }}"
-    displayName: "Git setup"
+    displayName: 'Git setup' 
 
   # Without this step, changes would be applied to a detached head
   - script: |
       git checkout ${{ parameters.release_branch }}
-    displayName: "Checkout release branch"
+    displayName: 'Checkout release branch'
 
-    # Go to project folder (in case of multiple project under the same repo)
+  # Go to project folder (in case of multiple project under the same repo)
   - script: |
       cd ${{ parameters.project_folder }}
     displayName: "Go to project folder"
-
+        
   # setup Node runtime
   - task: UseNode@1
     inputs:
-      version: "${{ parameters.nodeVersion }}"
-    displayName: "Set up Node.js"
+      version: '${{ parameters.nodeVersion }}'
+    displayName: 'Set up Node.js'
   - task: Cache@2
     inputs:
       key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | yarn.lock'
       restoreKeys: |
         yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"
-      path: "${{ parameters.pkg_cache_folder }}"
-    displayName: "Cache yarn packages"
+      path: '${{ parameters.pkg_cache_folder }}'
+    displayName: 'Cache yarn packages'
   - script: |
       yarn install --frozen-lockfile --no-progress --non-interactive --network-concurrency 1
-    displayName: "Install node modules"
+    displayName: 'Install node modules'
     condition: ne(variables.CACHE_RESTORED, 'true')
-
+    
   # bump version
   - script: |
       npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
       NEXT_VERSION=$(node -p "require('./package.json').version")
       RELEASE_TAG="v$NEXT_VERSION-RELEASE"
       git tag $RELEASE_TAG
-    displayName: "Version bump and tag"
+    displayName: 'Version bump and tag'
   - script: |
       NEXT_VERSION=$(node -p "require('./package.json').version")
       HEAD_SHA=$(git rev-parse HEAD)
@@ -93,12 +94,12 @@ steps:
       echo "##vso[task.setvariable variable=title]$TITLE"
       echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
       echo "##vso[task.setvariable variable=tag]$TAG"
-    displayName: "Set release variables"
+    displayName: 'Set release variables'
 
   # push new version
   - script: |
       git push origin ${{ parameters.release_branch }} && git push --tags
-    displayName: "Push to the release branch"
+    displayName: 'Push to the release branch'
 
   # create new releae
   - task: GitHubRelease@0

--- a/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
+++ b/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
@@ -57,10 +57,10 @@ steps:
       git checkout ${{ parameters.release_branch }}
     displayName: 'Checkout release branch'
 
-  # Go to project folder (in case of multiple project under the same repo)
-  - script: |
-      cd ${{ parameters.project_folder }}
-    displayName: "Go to project folder"
+  # # Go to project folder (in case of multiple project under the same repo)
+  # - script: |
+  #     cd ${{ parameters.project_folder }}
+  #   displayName: "Go to project folder"
         
   # setup Node runtime
   - task: UseNode@1
@@ -69,8 +69,7 @@ steps:
     displayName: 'Set up Node.js'
   - task: Cache@2
     inputs:
-      workingDirectory: io-pay-portal-fe
-      key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | io-pay-portal-fe/yarn.lock'
+      key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | ${{ parameters.project_folder }}/yarn.lock'
       restoreKeys: |
         yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"
       path: '${{ parameters.pkg_cache_folder }}'
@@ -81,35 +80,35 @@ steps:
     condition: ne(variables.CACHE_RESTORED, 'true')
     
   # bump version
-  - script: |
-      npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
-      NEXT_VERSION=$(node -p "require('./package.json').version")
-      RELEASE_TAG="v$NEXT_VERSION-RELEASE"
-      git tag $RELEASE_TAG
-    displayName: 'Version bump and tag'
-  - script: |
-      NEXT_VERSION=$(node -p "require('./package.json').version")
-      HEAD_SHA=$(git rev-parse HEAD)
-      TITLE="Release $NEXT_VERSION"
-      TAG="v$NEXT_VERSION-RELEASE"
-      echo "##vso[task.setvariable variable=title]$TITLE"
-      echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
-      echo "##vso[task.setvariable variable=tag]$TAG"
-    displayName: 'Set release variables'
+  # - script: |
+  #     npm version ${{ parameters.semver }} -m "Bump version to %s [skip ci]"
+  #     NEXT_VERSION=$(node -p "require('./${{ parameters.project_folder }}/package.json').version")
+  #     RELEASE_TAG="v$NEXT_VERSION-RELEASE"
+  #     git tag $RELEASE_TAG
+  #   displayName: 'Version bump and tag'
+  # - script: |
+  #     NEXT_VERSION=$(node -p "require('./${{ parameters.project_folder }}/package.json').version")
+  #     HEAD_SHA=$(git rev-parse HEAD)
+  #     TITLE="Release $NEXT_VERSION"
+  #     TAG="v$NEXT_VERSION-RELEASE"
+  #     echo "##vso[task.setvariable variable=title]$TITLE"
+  #     echo "##vso[task.setvariable variable=sha]$HEAD_SHA"
+  #     echo "##vso[task.setvariable variable=tag]$TAG"
+  #   displayName: 'Set release variables'
 
   # push new version
-  - script: |
-      git push origin ${{ parameters.release_branch }} && git push --tags
-    displayName: 'Push to the release branch'
+  # - script: |
+  #     git push origin ${{ parameters.release_branch }} && git push --tags
+  #   displayName: 'Push to the release branch'
 
   # create new releae
-  - task: GitHubRelease@0
-    inputs:
-      gitHubConnection: ${{ parameters.gitHubConnection }}
-      repositoryName: $(Build.Repository.Name)
-      action: create
-      target: $(sha)
-      tagSource: manual
-      tag: $(tag)
-      title: $(title)
-      addChangelog: true
+  # - task: GitHubRelease@0
+  #   inputs:
+  #     gitHubConnection: ${{ parameters.gitHubConnection }}
+  #     repositoryName: $(Build.Repository.Name)
+  #     action: create
+  #     target: $(sha)
+  #     tagSource: manual
+  #     tag: $(tag)
+  #     title: $(title)
+  #     addChangelog: true

--- a/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
+++ b/io-pay-portal-fe/.devops/azure-templates/node-github-release.yaml
@@ -70,7 +70,7 @@ steps:
   - task: Cache@2
     inputs:
       workingDirectory: io-pay-portal-fe
-      key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | yarn.lock'
+      key: 'yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)" | io-pay-portal-fe/yarn.lock'
       restoreKeys: |
         yarn-${{ parameters.pkg_cache_version_id }} | "$(Agent.OS)"
       path: '${{ parameters.pkg_cache_folder }}'

--- a/io-pay-portal-fe/.devops/deploy-pipelines.yml
+++ b/io-pay-portal-fe/.devops/deploy-pipelines.yml
@@ -3,6 +3,7 @@
 variables:
   NODE_VERSION: '12.19.1'
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/io-pay-portal-fe/.yarn
+  GITHUB_RELEASE_TEMPLATE: 'azure-templates/node-github-release.yaml'
 
 parameters:
   - name: 'RELEASE_SEMVER'
@@ -25,14 +26,6 @@ pr: none
 # the build and deploy.
 pool:
   vmImage: 'windows-2019'
-
-resources:
-  repositories:
-    - repository: pagopaCommons
-      type: github
-      name: pagopa/azure-pipeline-templates
-      ref: refs/tags/v4
-      endpoint: 'pagopa'
 
 stages:
 
@@ -58,9 +51,10 @@ stages:
       - job: make_release
         steps:
         - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-          - template: templates/node-github-release/template.yaml@pagopaCommons 
+          - template: $(GITHUB_RELEASE_TEMPLATE) 
             parameters:
               release_branch: 'main'
+              project_folder: 'io-pay-portal-fe/'
               semver: '${{ parameters.RELEASE_SEMVER }}'
               gitEmail: $(GIT_EMAIL)
               gitUsername: $(GIT_USERNAME)

--- a/io-pay-portal-fe/.devops/deploy-pipelines.yml
+++ b/io-pay-portal-fe/.devops/deploy-pipelines.yml
@@ -3,7 +3,7 @@
 variables:
   NODE_VERSION: '12.19.1'
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/io-pay-portal-fe/.yarn
-  GITHUB_RELEASE_TEMPLATE: 'azure-templates/node-github-release.yaml'
+  GITHUB_RELEASE_TEMPLATE: azure-templates/node-github-release.yaml
 
 parameters:
   - name: 'RELEASE_SEMVER'

--- a/io-pay-portal-fe/.devops/deploy-pipelines.yml
+++ b/io-pay-portal-fe/.devops/deploy-pipelines.yml
@@ -34,34 +34,34 @@ stages:
   # - is on branch master 
   # - is a tag in the form v{version}-RELEASE
   - stage: Release
-    condition:
-      and(
-        succeeded(),
-        or(
-          eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-          and(
-            startsWith(variables['Build.SourceBranch'], 'refs/tags'),
-            endsWith(variables['Build.SourceBranch'], '-RELEASE')
-          )
-        )
-      )
+    # condition:
+    #   and(
+    #     succeeded(),
+    #     or(
+    #       eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+    #       and(
+    #         startsWith(variables['Build.SourceBranch'], 'refs/tags'),
+    #         endsWith(variables['Build.SourceBranch'], '-RELEASE')
+    #       )
+    #     )
+    #   )
     pool:
       vmImage: 'ubuntu-latest'
     jobs:
       - job: make_release
         steps:
-        - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-          - template: $(GITHUB_RELEASE_TEMPLATE) 
-            parameters:
-              release_branch: 'main'
-              project_folder: 'io-pay-portal-fe/'
-              semver: '${{ parameters.RELEASE_SEMVER }}'
-              gitEmail: $(GIT_EMAIL)
-              gitUsername: $(GIT_USERNAME)
-              gitHubConnection: $(GITHUB_CONNECTION)
-              nodeVersion: $(NODE_VERSION)
-              pkg_cache_version_id: $(CACHE_VERSION_ID)
-              pkg_cache_folder: $(YARN_CACHE_FOLDER)
+        # - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        - template: $(GITHUB_RELEASE_TEMPLATE) 
+          parameters:
+            release_branch: 'main'
+            project_folder: 'io-pay-portal-fe/'
+            semver: '${{ parameters.RELEASE_SEMVER }}'
+            gitEmail: $(GIT_EMAIL)
+            gitUsername: $(GIT_USERNAME)
+            gitHubConnection: $(GITHUB_CONNECTION)
+            nodeVersion: $(NODE_VERSION)
+            pkg_cache_version_id: $(CACHE_VERSION_ID)
+            pkg_cache_folder: $(YARN_CACHE_FOLDER)
 
         - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
           - script: |

--- a/io-pay-portal-fe/.devops/deploy-pipelines.yml
+++ b/io-pay-portal-fe/.devops/deploy-pipelines.yml
@@ -3,7 +3,7 @@
 variables:
   NODE_VERSION: '12.19.1'
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/io-pay-portal-fe/.yarn
-  GITHUB_RELEASE_TEMPLATE: azure-templates/node-github-release.yaml
+  # GITHUB_RELEASE_TEMPLATE: azure-templates/node-github-release.yaml
 
 parameters:
   - name: 'RELEASE_SEMVER'
@@ -51,7 +51,7 @@ stages:
       - job: make_release
         steps:
         # - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-        - template: $(GITHUB_RELEASE_TEMPLATE) 
+        - template: azure-templates/node-github-release.yaml
           parameters:
             release_branch: 'main'
             project_folder: 'io-pay-portal-fe/'


### PR DESCRIPTION
added node-github-release.yml template to FE .devops file. This file contains a new variable "project_folder", so we can jump into a specific folder (set to 'io-pay-portal-fe/' into deploy-pipelines.yml)

We need to undestand how to manage different tags for FE and BE. 