### PR TITLE
[#176942427] Added methodResume and challengeResume functions for 3ds2

### DIFF
--- a/io-functions-pay-portal/PostTransactionsChallenge3ds2/function.json
+++ b/io-functions-pay-portal/PostTransactionsChallenge3ds2/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/transactions/{id}/challenge",
+      "methods": [
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/PostTransactionsChallenge3ds2/index.js"
+}

--- a/io-functions-pay-portal/PostTransactionsChallenge3ds2/index.ts
+++ b/io-functions-pay-portal/PostTransactionsChallenge3ds2/index.ts
@@ -1,0 +1,50 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+import { getConfigOrThrow } from "../utils/config";
+import { challengePage } from "../utils/page3ds";
+
+const config = getConfigOrThrow();
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+// Setup Express
+const app = express();
+
+secureExpressApp(app);
+
+// Add express route
+
+app.post("/api/v1/transactions/:id/challenge", (req, res) => {
+  res.set("Content-Type", "text/html");
+  return res.send(
+    challengePage
+      .replace(
+        "IO_PAY_CHALLENGE_RESUME_URL",
+        config.IO_PAY_CHALLENGE_RESUME_URL
+      )
+      .replace("id", req.params.id)
+  );
+});
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/io-functions-pay-portal/PostTransactionsMethod3ds2/function.json
+++ b/io-functions-pay-portal/PostTransactionsMethod3ds2/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/transactions/{id}/method",
+      "methods": [
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/PostTransactionsMethod3ds2/index.js"
+}

--- a/io-functions-pay-portal/PostTransactionsMethod3ds2/index.ts
+++ b/io-functions-pay-portal/PostTransactionsMethod3ds2/index.ts
@@ -1,0 +1,40 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+import { methodPage } from "../utils/page3ds";
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+// Setup Express
+const app = express();
+
+secureExpressApp(app);
+
+// Add express route
+
+app.post("/api/v1/transactions/:id/method/", (_, res) => {
+  res.set("Content-Type", "text/html");
+  return res.send(methodPage);
+});
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/io-functions-pay-portal/env.example
+++ b/io-functions-pay-portal/env.example
@@ -12,4 +12,5 @@ NODE_ENV=develop
 
 IO_PAGOPA_PROXY_PROD_BASE_URL=http://pagopa-proxy:3001
 IO_PAGOPA_PROXY_TEST_BASE_URL=http://pagopa-proxy:3001
+IO_PAY_CHALLENGE_RESUME_URL=http://io-pay/transactions/id/resume
 PAGOPA_BASE_PATH=/

--- a/io-functions-pay-portal/utils/config.ts
+++ b/io-functions-pay-portal/utils/config.ts
@@ -14,6 +14,7 @@ export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.interface({
   IO_PAGOPA_PROXY_PROD_BASE_URL: NonEmptyString,
   IO_PAGOPA_PROXY_TEST_BASE_URL: NonEmptyString,
+  IO_PAY_CHALLENGE_RESUME_URL: NonEmptyString,
   PAGOPA_BASE_PATH: NonEmptyString
 });
 

--- a/io-functions-pay-portal/utils/page3ds.ts
+++ b/io-functions-pay-portal/utils/page3ds.ts
@@ -1,0 +1,5 @@
+export const methodPage =
+  '<html><head><script>var getUrl = window.location;window.parent.postMessage("3DS.Notification.Received", getUrl.protocol + "//" + getUrl.host);</script></head><body></body></html>';
+
+export const challengePage =
+  '<head><meta http-equiv="refresh" content="0; URL=IO_PAY_CHALLENGE_RESUME_URL"></head>';


### PR DESCRIPTION
#### Description

This PR introduces two functions to support 3ds2 flow for io-pay.

#### List of Changes

1. POST api/v1/transactions/{id}/method: return html page to complete _Method 3ds2_ step in IFrame of _io-pay_;
2. POST api/v1/transactions/{id}/challenge: return html page to redirect to _io-pay_;
  
#### Motivation and Context

The goal of this PR is to support _io-pay_ in  3ds2 flow with two POST API function, since _io-pay_ does not handle POST http  as it only serves static content.

#### How Has This Been Tested?

1. run function App with `yarn start `;
2. call with http client POST api/v1/transactions/{id}/method with a random id;
3. call with http client POST api/v1/transactions/{id}/challenge with a random id;

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
