### PR TITLE
[VF-10] Add ConfirmEmail=true in mailup api

### DIFF
--- a/io-functions-pay-portal/PostNewslettersRecipients/handler.ts
+++ b/io-functions-pay-portal/PostNewslettersRecipients/handler.ts
@@ -266,14 +266,14 @@ export const addRecipientToMailupTask = (
         email,
         name,
         token,
-        `/API/v1.1/Rest/ConsoleService.svc/Console/List/${idList}/Recipient`
+        `/API/v1.1/Rest/ConsoleService.svc/Console/List/${idList}/Recipient?ConfirmEmail=true`
       )
     : array.traverse(taskEither)([...groups], idGroup =>
         addRecipientToMailupListOrGroupTask(
           email,
           name,
           token,
-          `/API/v1.1/Rest/ConsoleService.svc/Console/Group/${idGroup}/Recipient`
+          `/API/v1.1/Rest/ConsoleService.svc/Console/Group/${idGroup}/Recipient?ConfirmEmail=true`
         )
       );
 


### PR DESCRIPTION
#### Description

This PR add a double optin procedure for the given recipient by adding the query string parameter `"ConfirmEmail=true"`, according to the [Mailup Documentation](https://help.mailup.com/display/mailupapi/Recipients#Recipients-Addasinglerecipient/subscriber-synchronousimport).