### PR TITLE
[IOPAY-111] New functions to support xpay and xpayVerification io-pay

### DIFF
--- a/io-functions-pay-portal/GetActivationStatus/__tests__/handler.test.ts
+++ b/io-functions-pay-portal/GetActivationStatus/__tests__/handler.test.ts
@@ -9,7 +9,8 @@ import { GetActivationStatusHandler } from "../handler";
 process.env = {
   IO_PAGOPA_PROXY_PROD_BASE_URL: "http://localhost:7071/api/v1",
   IO_PAGOPA_PROXY_TEST_BASE_URL: "http://localhost:7071/api/v1",
-  PAGOPA_BASE_PATH: "NonEmptyString"
+  PAGOPA_BASE_PATH: "NonEmptyString",
+  IO_PAY_XPAY_REDIRECT: "http://localhost"
 };
 // debug("ENV", process.env);
 

--- a/io-functions-pay-portal/GetPaymentInfo/__tests__/handler.test.ts
+++ b/io-functions-pay-portal/GetPaymentInfo/__tests__/handler.test.ts
@@ -20,7 +20,8 @@ import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 process.env = {
   IO_PAGOPA_PROXY_PROD_BASE_URL: "http://localhost:7071/api/v1",
   IO_PAGOPA_PROXY_TEST_BASE_URL: "http://localhost:7071/api/v1",
-  PAGOPA_BASE_PATH: "NonEmptyString"
+  PAGOPA_BASE_PATH: "NonEmptyString",
+  IO_PAY_XPAY_REDIRECT: "http://localhost"
 };
 // debug("ENV", process.env);
 

--- a/io-functions-pay-portal/GetTransactionsXpay/function.json
+++ b/io-functions-pay-portal/GetTransactionsXpay/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/transactions/xpay/{id}",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetTransactionsXpay/index.js"
+}

--- a/io-functions-pay-portal/GetTransactionsXpay/index.ts
+++ b/io-functions-pay-portal/GetTransactionsXpay/index.ts
@@ -30,37 +30,14 @@ secureExpressApp(app);
 // Add express route
 app.get("/api/v1/transactions/xpay/:id", (req, res) => {
   res.set("Content-Type", "text/html");
+  const i = req.originalUrl.indexOf("?");
+  const queryParams = req.originalUrl.slice(i + 1);
   return res.send(
     xpayRedirectPage
       .replace("IO_PAY_XPAY_REDIRECT", config.IO_PAY_XPAY_REDIRECT)
       .replace("_id_", req.params.id)
-      .replace("_esito_", fromNullable(req.query.esito).getOrElse("") as string)
-      .replace(
-        "_idOperazione_",
-        fromNullable(req.query.idOperazione).getOrElse("") as string
-      )
-      .replace(
-        "_timeStamp_",
-        fromNullable(req.query.timeStamp).getOrElse("") as string
-      )
-      .replace("_mac_", fromNullable(req.query.mac).getOrElse("") as string)
-      .replace(
-        "_xpayNonce_",
-        fromNullable(req.query.xpayNonce).getOrElse("") as string
-      )
-      .replace(
-        "_outcome_",
-        fromNullable(req.query.outcome).getOrElse("") as string
-      )
-      .replace(
-        "_codice_",
-        fromNullable(req.query.codice).getOrElse("") as string
-      )
-      .replace(
-        "_messaggio_",
-        fromNullable(req.query.messaggio).getOrElse("") as string
-      )
       .replace("_resumeType_", "xpay")
+      .replace("_queryParams_", queryParams)
   );
 });
 

--- a/io-functions-pay-portal/GetTransactionsXpay/index.ts
+++ b/io-functions-pay-portal/GetTransactionsXpay/index.ts
@@ -1,0 +1,76 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+
+import { fromNullable } from "fp-ts/lib/Option";
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+import { getConfigOrThrow } from "../utils/config";
+
+const config = getConfigOrThrow();
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+const xpayRedirectPage =
+  '<head><meta http-equiv="refresh" content="0; URL=IO_PAY_XPAY_REDIRECT"></head>';
+
+// Setup Express
+const app = express();
+
+secureExpressApp(app);
+
+// Add express route
+app.get("/api/v1/transactions/xpay/:id", (req, res) => {
+  res.set("Content-Type", "text/html");
+  return res.send(
+    xpayRedirectPage
+      .replace("IO_PAY_XPAY_REDIRECT", config.IO_PAY_XPAY_REDIRECT)
+      .replace("_id_", req.params.id)
+      .replace("_esito_", fromNullable(req.query.esito).getOrElse("") as string)
+      .replace(
+        "_idOperazione_",
+        fromNullable(req.query.idOperazione).getOrElse("") as string
+      )
+      .replace(
+        "_timeStamp_",
+        fromNullable(req.query.timeStamp).getOrElse("") as string
+      )
+      .replace("_mac_", fromNullable(req.query.mac).getOrElse("") as string)
+      .replace(
+        "_xpayNonce_",
+        fromNullable(req.query.xpayNonce).getOrElse("") as string
+      )
+      .replace(
+        "_outcome_",
+        fromNullable(req.query.outcome).getOrElse("") as string
+      )
+      .replace(
+        "_codice_",
+        fromNullable(req.query.codice).getOrElse("") as string
+      )
+      .replace(
+        "_messaggio_",
+        fromNullable(req.query.messaggio).getOrElse("") as string
+      )
+      .replace("_resumeType_", "xpay")
+  );
+});
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/io-functions-pay-portal/GetTransactionsXpayVerification/function.json
+++ b/io-functions-pay-portal/GetTransactionsXpayVerification/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "api/v1/transactions/xpay/verification/{id}",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetTransactionsXpayVerification/index.js"
+}

--- a/io-functions-pay-portal/GetTransactionsXpayVerification/index.ts
+++ b/io-functions-pay-portal/GetTransactionsXpayVerification/index.ts
@@ -30,37 +30,14 @@ secureExpressApp(app);
 // Add express route
 app.get("/api/v1/transactions/xpay/verification/:id", (req, res) => {
   res.set("Content-Type", "text/html");
+  const i = req.originalUrl.indexOf("?");
+  const queryParams = req.originalUrl.slice(i + 1);
   return res.send(
     xpayRedirectPage
       .replace("IO_PAY_XPAY_REDIRECT", config.IO_PAY_XPAY_REDIRECT)
       .replace("_id_", req.params.id)
-      .replace("_esito_", fromNullable(req.query.esito).getOrElse("") as string)
-      .replace(
-        "_idOperazione_",
-        fromNullable(req.query.idOperazione).getOrElse("") as string
-      )
-      .replace(
-        "_timeStamp_",
-        fromNullable(req.query.timeStamp).getOrElse("") as string
-      )
-      .replace("_mac_", fromNullable(req.query.mac).getOrElse("") as string)
-      .replace(
-        "_xpayNonce_",
-        fromNullable(req.query.xpayNonce).getOrElse("") as string
-      )
-      .replace(
-        "_outcome_",
-        fromNullable(req.query.outcome).getOrElse("") as string
-      )
-      .replace(
-        "_codice_",
-        fromNullable(req.query.codice).getOrElse("") as string
-      )
-      .replace(
-        "_messaggio_",
-        fromNullable(req.query.messaggio).getOrElse("") as string
-      )
       .replace("_resumeType_", "xpayVerification")
+      .replace("_queryParams_", queryParams)
   );
 });
 

--- a/io-functions-pay-portal/GetTransactionsXpayVerification/index.ts
+++ b/io-functions-pay-portal/GetTransactionsXpayVerification/index.ts
@@ -1,0 +1,76 @@
+import * as express from "express";
+import * as winston from "winston";
+
+import { Context } from "@azure/functions";
+
+import { fromNullable } from "fp-ts/lib/Option";
+import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
+import { AzureContextTransport } from "io-functions-commons/dist/src/utils/logging";
+import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
+import { getConfigOrThrow } from "../utils/config";
+
+const config = getConfigOrThrow();
+
+// tslint:disable-next-line: no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+const xpayRedirectPage =
+  '<head><meta http-equiv="refresh" content="0; URL=IO_PAY_XPAY_REDIRECT"></head>';
+
+// Setup Express
+const app = express();
+
+secureExpressApp(app);
+
+// Add express route
+app.get("/api/v1/transactions/xpay/verification/:id", (req, res) => {
+  res.set("Content-Type", "text/html");
+  return res.send(
+    xpayRedirectPage
+      .replace("IO_PAY_XPAY_REDIRECT", config.IO_PAY_XPAY_REDIRECT)
+      .replace("_id_", req.params.id)
+      .replace("_esito_", fromNullable(req.query.esito).getOrElse("") as string)
+      .replace(
+        "_idOperazione_",
+        fromNullable(req.query.idOperazione).getOrElse("") as string
+      )
+      .replace(
+        "_timeStamp_",
+        fromNullable(req.query.timeStamp).getOrElse("") as string
+      )
+      .replace("_mac_", fromNullable(req.query.mac).getOrElse("") as string)
+      .replace(
+        "_xpayNonce_",
+        fromNullable(req.query.xpayNonce).getOrElse("") as string
+      )
+      .replace(
+        "_outcome_",
+        fromNullable(req.query.outcome).getOrElse("") as string
+      )
+      .replace(
+        "_codice_",
+        fromNullable(req.query.codice).getOrElse("") as string
+      )
+      .replace(
+        "_messaggio_",
+        fromNullable(req.query.messaggio).getOrElse("") as string
+      )
+      .replace("_resumeType_", "xpayVerification")
+  );
+});
+
+const azureFunctionHandler = createAzureFunctionHandler(app);
+
+// Binds the express app to an Azure Function handler
+function httpStart(context: Context): void {
+  logger = context.log;
+  setAppContext(app, context);
+  azureFunctionHandler(context);
+}
+
+export default httpStart;

--- a/io-functions-pay-portal/PostNewslettersRecipients/__tests__/handler.test.ts
+++ b/io-functions-pay-portal/PostNewslettersRecipients/__tests__/handler.test.ts
@@ -9,6 +9,8 @@ process.env = {
   IO_PAY_CHALLENGE_RESUME_URL:
     "http://localhost:1234/response.html?id=idTransaction",
   IO_PAY_ORIGIN: "http://localhost:1234",
+  IO_PAY_XPAY_REDIRECT: "http://localhost",
+
   PAGOPA_BASE_PATH: "NonEmptyString",
 
   MAILUP_ALLOWED_GROUPS: "6,123",

--- a/io-functions-pay-portal/env.example
+++ b/io-functions-pay-portal/env.example
@@ -24,5 +24,6 @@ RECAPTCHA_SECRET=6dddddd0P7N0dddddTdd
 
 IO_PAY_CHALLENGE_RESUME_URL=http://localhost:1234/response.html?id=idTransaction
 IO_PAY_ORIGIN=http://localhost:1234/response.html?id=idTransaction
+IO_PAY_XPAY_REDIRECT=http://localhost:1234/response.html?id=_id_&esito=_esito_&idOperazione=_idOperazione_&timeStamp=_timeStamp_&mac=_mac_&xpayNonce=_xpayNonce_&outcome=_outcome_&codice=_codice_&messaggio=_messaggio_&resumeType=_resumeType_
 
 PAGOPA_BASE_PATH=/

--- a/io-functions-pay-portal/env.example
+++ b/io-functions-pay-portal/env.example
@@ -24,6 +24,6 @@ RECAPTCHA_SECRET=6dddddd0P7N0dddddTdd
 
 IO_PAY_CHALLENGE_RESUME_URL=http://localhost:1234/response.html?id=idTransaction
 IO_PAY_ORIGIN=http://localhost:1234/response.html?id=idTransaction
-IO_PAY_XPAY_REDIRECT=http://localhost:1234/response.html?id=_id_&esito=_esito_&idOperazione=_idOperazione_&timeStamp=_timeStamp_&mac=_mac_&xpayNonce=_xpayNonce_&outcome=_outcome_&codice=_codice_&messaggio=_messaggio_&resumeType=_resumeType_
+IO_PAY_XPAY_REDIRECT=http://localhost:1234/response.html?id=_id_&resumeType=_resumeType_&_queryParams_
 
 PAGOPA_BASE_PATH=/

--- a/io-functions-pay-portal/utils/config.ts
+++ b/io-functions-pay-portal/utils/config.ts
@@ -16,6 +16,7 @@ export const IConfig = t.interface({
   IO_PAGOPA_PROXY_TEST_BASE_URL: NonEmptyString,
   IO_PAY_CHALLENGE_RESUME_URL: NonEmptyString,
   IO_PAY_ORIGIN: NonEmptyString,
+  IO_PAY_XPAY_REDIRECT: NonEmptyString,
   MAILUP_ALLOWED_GROUPS: t.array(t.string).type,
   MAILUP_ALLOWED_LISTS: t.array(t.string).type,
   MAILUP_CLIENT_ID: NonEmptyString,


### PR DESCRIPTION
### Description

This PR adds two functions to support _xpay_ and _xpayVerification_ steps in _io-pay_.

#### List of Changes

1. added `GET api/v1/transactions/xpay/{id}?queryParams` , that redirect to _io-pay_ passing all the request query parameters and setting `resumeType` to `xpay`.
2. added `GET api/v1/transactions/xpay/verification/{id}?queryParams` , that redirect to _io-pay_ passing all the request query parameters and setting `resumeType` to `xpayVerification`.
3. added new env variable `IO_PAY_XPAY_REDIRECT`. 
 
#### Motivation and Context

For more details for _Xpay_ payments read [here](https://pagopa.atlassian.net/wiki/spaces/I/pages/84934691/Analisi+tecnica+IO-Pay#4.-IO-PAY---focus-flusso-3ds2-(nexi)).

#### How Has This Been Tested?

1. `yarn build`
2. `yarn start`
3. invoke the two new functions and check the the returned html:
    - `GET http://localhost:7071/api/v1/transactions/xpay/MjI0Mw==?esito=OK&idOperazione=18757618&timeStamp=1618311883750&mac=sdfdsfsdfsdf&xpayNonce=dsfd-ead0-dsfd-dsfd-dsfd`
    - `GET http://localhost:7071/api/v1/transactions/xpay/verification/MjI0Mw==?esito=OK&idOperazione=18757618&timeStamp=1618311883750&mac=sdfdsfsdfsdf&xpayNonce=dsfd-ead0-dsfd-dsfd-dsfd`
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
