### PR TITLE
[#IOPAY-206] Break text when subject is too long

### DIFF
--- a/io-pay-portal-fe/src/index.pug
+++ b/io-pay-portal-fe/src/index.pug
@@ -59,7 +59,7 @@ html(lang='it')
                                 div.font-weight-bold(id="ec") 
                             .windowcont__caus.py-2.mt-2.border-bottom.border-bottom-gray.reset-font-size
                                 div.text-muted Causale
-                                div.font-weight-bold(id="causale") 
+                                div.font-weight-bold.text-break(id="causale") 
                             .windowcont__cfec.py-2.mt-2.border-bottom.border-bottom-gray.reset-font-size.d-flex
                                 div.text-muted Codice Fiscale Ente Creditore
                                 div.font-weight-bold.ml-auto(id="cf-pa")


### PR DESCRIPTION
This PR solve cosmetic issue: when the "subject" is too long, the text is breaked in multiple rows

#### List of Changes

Added a text-break class

#### Motivation and Context

When the "subject" is too long, the text is breaked in multiple rows

#### How Has This Been Tested?

Linter

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
