### PR TITLE
FIX: decimal amount

### DIFF
--- a/io-pay-portal-fe/src/helper.ts
+++ b/io-pay-portal-fe/src/helper.ts
@@ -239,9 +239,9 @@ export const showPaymentInfo = (paymentInfo: PaymentRequestsGetResponse) => {
     const prettifiedImporto =
       parseInt(paymentInfo.importoSingoloVersamento.toString(), 10) / 100;
     // eslint-disable-next-line functional/immutable-data
-    importo.innerText = `€ ${Intl.NumberFormat("it-IT", { minimumFractionDigits: 2 }).format(
-      prettifiedImporto
-    )}`;
+    importo.innerText = `€ ${Intl.NumberFormat("it-IT", {
+      minimumFractionDigits: 2,
+    }).format(prettifiedImporto)}`;
   }
   if (cfpa) {
     // eslint-disable-next-line functional/immutable-data

--- a/io-pay-portal-fe/src/helper.ts
+++ b/io-pay-portal-fe/src/helper.ts
@@ -239,7 +239,7 @@ export const showPaymentInfo = (paymentInfo: PaymentRequestsGetResponse) => {
     const prettifiedImporto =
       parseInt(paymentInfo.importoSingoloVersamento.toString(), 10) / 100;
     // eslint-disable-next-line functional/immutable-data
-    importo.innerText = `€ ${Intl.NumberFormat("it-IT").format(
+    importo.innerText = `€ ${Intl.NumberFormat("it-IT", { minimumFractionDigits: 2 }).format(
       prettifiedImporto
     )}`;
   }


### PR DESCRIPTION
This PR fixes a cosmetic issue related to the display of the amount: always two decimal also when there are "00".
(eg. € 11,00 instead of €11)

#### List of Changes

Added a "long display" paramenter to the numberformat function

#### Motivation and Context

Cosmetic issue

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
