### PR TITLE
[IOPAY-234] Add reason in mixpanel event

### DIFF
--- a/io-pay-portal-fe/dev-server.js
+++ b/io-pay-portal-fe/dev-server.js
@@ -14,8 +14,9 @@ app.get("/api/payportal/v1/payment-requests/:rptId", (_, res) => {
   // test scenario for an error message
   if (_.params.rptId == "00000000000000000000000000000" ) {
     res.status(500).send("Error!");
-  }
-  else {
+  } else if (_.params.rptId == "00000000000000000000000000009" ) {
+    res.status(400).send( { detail: "PAYMENT_DUPLICATED" } );
+  } else {
     res.send({
       importoSingoloVersamento: 1100,
       codiceContestoPagamento: "6f69d150541e11ebb70c7b05c53756dd",

--- a/io-pay-portal-fe/src/helper.ts
+++ b/io-pay-portal-fe/src/helper.ts
@@ -92,12 +92,13 @@ export const getPaymentInfoTask = (
       errorOrResponse.fold(
         () => fromLeft("Errore recupero pagamento"),
         (responseType) => {
+          const reason =
+            responseType.status === 200 ? "" : responseType.value?.detail;
           const EVENT_ID: string =
             responseType.status === 200
               ? PAYMENT_VERIFY_SUCCESS.value
               : PAYMENT_VERIFY_RESP_ERR.value;
-          mixpanel.track(EVENT_ID, { EVENT_ID });
-
+          mixpanel.track(EVENT_ID, { EVENT_ID, reason });
           return responseType.status !== 200
             ? fromLeft(
                 fromNullable(responseType.value?.detail).getOrElse(


### PR DESCRIPTION
#### List of Changes

- add _reason_ as property of mixpanel event;

#### Motivation and Context

The goal of this PR is to add the property _reason_ in the mixpanel event with a detail of the error returned by the API.

#### How Has This Been Tested?

Run locally the application and check in browser console the body of mixpanel event. 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
