### PR TITLE
Disable current_url and initial_referrer in mixpanel events

### DIFF
--- a/io-pay-portal-fe/src/util/mixpanelHelperInit.ts
+++ b/io-pay-portal-fe/src/util/mixpanelHelperInit.ts
@@ -73,6 +73,7 @@ export const mixpanelInit = function (): void {
       api_host: "https://api-eu.mixpanel.com",
       persistence: "localStorage",
       ip: false,
+      property_blacklist: ['$current_url', '$initial_referrer'],
       loaded(mixpanel: Mixpanel) {
         // this is useful to obtain a new distinct_id every session
         mixpanel.reset();

--- a/io-pay-portal-fe/src/util/mixpanelHelperInit.ts
+++ b/io-pay-portal-fe/src/util/mixpanelHelperInit.ts
@@ -73,7 +73,7 @@ export const mixpanelInit = function (): void {
       api_host: "https://api-eu.mixpanel.com",
       persistence: "localStorage",
       ip: false,
-      property_blacklist: ['$current_url', '$initial_referrer'],
+      property_blacklist: ["$current_url", "$initial_referrer"],
       loaded(mixpanel: Mixpanel) {
         // this is useful to obtain a new distinct_id every session
         mixpanel.reset();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- add  `property_blacklist` with  ` ["$current_url", "$initial_referrer"]` in mixpanel initial setup.

#### Motivation and Context

The goal of this PR is to avoid urls in mixpanel events.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
