### PR TITLE
[HOTFIX] Set timeout on activate instead of verify

### DIFF
--- a/io-pay-portal-fe/src/index.ts
+++ b/io-pay-portal-fe/src/index.ts
@@ -344,7 +344,7 @@ document.addEventListener("DOMContentLoaded", () => {
     async (evt): Promise<void> => {
       evt.preventDefault();
       document.body.classList.add("loading");
-      
+
       /**
        * recaptcha challenge: get token running recaptchaCallback()
        */

--- a/io-pay-portal-fe/src/index.ts
+++ b/io-pay-portal-fe/src/index.ts
@@ -344,10 +344,7 @@ document.addEventListener("DOMContentLoaded", () => {
     async (evt): Promise<void> => {
       evt.preventDefault();
       document.body.classList.add("loading");
-      setTimeout(
-        () => delayAlert?.classList.add("active"),
-        (getConfig("IO_PAY_PORTAL_PAY_WL_POLLING_ALERT") as Millisecond) || 6000
-      );
+      
       /**
        * recaptcha challenge: get token running recaptchaCallback()
        */
@@ -381,7 +378,10 @@ document.addEventListener("DOMContentLoaded", () => {
     async (evt): Promise<void> => {
       evt.preventDefault();
       document.body.classList.add("loading");
-
+      setTimeout(
+        () => delayAlert?.classList.add("active"),
+        (getConfig("IO_PAY_PORTAL_PAY_WL_POLLING_ALERT") as Millisecond) || 6000
+      );
       /**
        * recaptcha challenge: get token running preActivationRecaptchaCallback()
        */


### PR DESCRIPTION
After a conflict resolution, the setTimeout was setted on the "verify flow", instead of "activation flow".
This PR fix this putting the setTimeout in the right place

#### List of Changes

- modify index code setting setTimout on `active` event


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
